### PR TITLE
Add network policy on elasticsearch chart

### DIFF
--- a/elasticsearch/Chart.yaml
+++ b/elasticsearch/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Elasticsearch
 name: elasticsearch
-version: 0.2.2
+version: 0.3.0

--- a/elasticsearch/templates/NOTES.txt
+++ b/elasticsearch/templates/NOTES.txt
@@ -1,1 +1,7 @@
  ES url: http://{{ template "elasticsearch.fullname" . }}:{{ .Values.service.externalPort }}
+
+To connect to your database run the following command (using the env variable from above):
+
+   kubectl run {{ template "elasticsearch.fullname" . }}-client --rm -ti --image=ubuntu \{{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+   --labels="{{ template "elasticsearch.fullname" . }}-client=true" \{{- end }}
+   -- /bin/bash

--- a/elasticsearch/templates/network-policy.yaml
+++ b/elasticsearch/templates/network-policy.yaml
@@ -1,0 +1,33 @@
+---
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "elasticsearch.fullname" . }}
+  labels:
+    app: {{ template "elasticsearch.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
+  ingress:
+  # Allow inbound connections
+  - ports:
+    # ElasticSearch port
+    - port: {{ .Values.port }}
+      protocol: TCP
+    from:
+  {{- if not .Values.networkPolicy.allowExternal }}
+    - podSelector:
+        matchLabels:
+          app: {{ template "elasticsearch.name" . }}
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
+          {{ template "elasticsearch.fullname" . }}-client: "true"
+  {{- end }}
+{{- end }}

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -49,3 +49,15 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+networkPolicy:
+    ## Enable creation of NetworkPolicy resources.
+    ##
+    enabled: false
+
+    ## The Policy model to apply. When set to false, only pods with the correct
+    ## client label will have network access to the port ElasticSearch is listening
+    ## on. When true, ElasticSearch will accept connections from any source
+    ## (with the correct destination port).
+    ##
+    # allowExternal:


### PR DESCRIPTION
The network policy is disable by default. When it's activate only the
pod with the correct label can join the elasticsearch. An optional
argument can be pass to allow any pod to join the elasticsearch.