### PR TITLE
Filebeat Store filebeat data as nodes local files

### DIFF
--- a/kubernetes-filebeat/templates/daemonset-master.yaml
+++ b/kubernetes-filebeat/templates/daemonset-master.yaml
@@ -46,7 +46,7 @@ spec:
           readOnly: true
           subPath: filebeat.yml
         - name: data
-          mountPath: /usr/share/filebeat/data
+          mountPath: /usr/share/filebeat/data/
         - name: varlog
           mountPath: /var/log/
           readOnly: true
@@ -59,7 +59,9 @@ spec:
         hostPath:
           path: /var/log
       - name: data
-        emptyDir: {}
+        hostPath:
+          type: DirectoryOrCreate
+          path: /opt/filebeat
 
 ---
 # Node config

--- a/kubernetes-filebeat/templates/daemonset-nodes.yaml
+++ b/kubernetes-filebeat/templates/daemonset-nodes.yaml
@@ -44,7 +44,7 @@ spec:
           readOnly: true
           subPath: filebeat.yml
         - name: data
-          mountPath: /usr/share/filebeat/data
+          mountPath: /usr/share/filebeat/data/
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
@@ -57,7 +57,9 @@ spec:
         hostPath:
           path: /var/lib/docker/containers
       - name: data
-        emptyDir: {}
+        hostPath:
+          type: DirectoryOrCreate
+          path: /opt/filebeat
 
 ---
 # Node config


### PR DESCRIPTION
To avoid parsing logs at beginning each time a filebeat instance
is starting, we have to make the data volume persistent.

We use hostPath storage since this works on a daemonSet