### PR TITLE
Fix sts annotations and selector

### DIFF
--- a/elasticsearch/Chart.yaml
+++ b/elasticsearch/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Elasticsearch
 name: elasticsearch
-version: 2.0.0
+version: 2.0.1

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -8,14 +8,23 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "elasticsearch.name" . }}
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+      {{- if .Values.template.labels }}
+{{ toYaml .Values.template.labels | indent 6 }}
+      {{- end }}
   serviceName: {{ template "elasticsearch.name" . }}
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       annotations:
         log/pattern: "^\\[[0-9]{4}-[0-9]{2}-[0-9]{2}"
-        log/negate: true
-        log/match: after
+        log/negate: "true"
+        log/match: "after"
       labels:
         app: {{ template "elasticsearch.name" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
  In the new version apps/v1, the selector have to match the pod
  template. It is no more implicit.