### PR TITLE
Switch to awscli for elasticsearch init-data

### DIFF
--- a/elasticsearch/Chart.yaml
+++ b/elasticsearch/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Elasticsearch
 name: elasticsearch
-version: 2.0.2
+version: 2.0.3

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -25,23 +25,21 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `image`   | `elasticsearch` image repository and tag | `elasticsearch:2.3` |
 
 ### Expert
-| Parameter                                 | Description                                                         | Default           |
-| ---                                       | ---                                                                 | ---               |
-| `initData.enabled`                        | Use init container to inject data into elasticsearch                | `false`           |
-| `initData.image`                          | Image and tag used by the init container of data initialization     | `minio/mc:latest` |
-| `initData.datafile`                       | Name of the file to download                                        | `nil`             |
-| `initData.objectStorage.provider`         | Name of the provider to download the datafile from                  | `nil`             |
-| `initData.objectStorage.bucket`           | Name of the bucket to download the datafile from                    | `nil`             |
-| `initData.objectStorage.host`             | Name of the host to download the datafile from                      | `nil`             |
-| `initData.objectStorage.secretKeyRefName` | Name of the k8s secret with `access_key_id` and `secret_access_key` | `nil`             |
-| `service.name`                            | Name of the k8s service                                             | `es`              |
-| `service.type`                            | Type of the k8s service                                             | `ClusterIP`       |
-| `service.externalPort`                    | External port exposed by the k8s service                            | `3306`            |
-| `service.internalPort`                    | Internal port of the k8s service                                    | `3306`            |
-| `persistence.storageClassName`            | Storage class name of the persistence volume                        | `default`         |
-| `persistence.accessMode`                  | Access mode of the persistence volume                               | `ReadWriteOnce`   |
-| `persistence.size`                        | Internal port of the k8s service                                    | `3306`            |
-| `template.labels`                         | Labels to be added to the elasticsearch pod                         | `{}`              |
-| `resources`                               | Resources limits and requests for elasticsearch                     | `{}`              |
-| `networkPolicy.enabled`                   | Use network policy to filter ingress connections to elasticsearch   | `false`           |
-| `networkPolicy.allowExternal`             | Allow all ingress connections to elasticsearch                      | `nil`             |
+| Parameter                                 | Description                                                         | Default                   |
+| ---                                       | ---                                                                 | ---                       |
+| `initData.enabled`                        | Use init container to inject data into elasticsearch                | `false`                   |
+| `initData.image`                          | Image and tag used by the init container of data initialization     | `jobteaser/awscli:latest` |
+| `initData.datafile`                       | Name of the file to download                                        | `nil`                     |
+| `initData.objectStorage.bucket`           | Name of the bucket to download the datafile from                    | `nil`                     |
+| `initData.objectStorage.secretKeyRefName` | Name of the k8s secret with `access_key_id` and `secret_access_key` | `nil`                     |
+| `service.name`                            | Name of the k8s service                                             | `es`                      |
+| `service.type`                            | Type of the k8s service                                             | `ClusterIP`               |
+| `service.externalPort`                    | External port exposed by the k8s service                            | `3306`                    |
+| `service.internalPort`                    | Internal port of the k8s service                                    | `3306`                    |
+| `persistence.storageClassName`            | Storage class name of the persistence volume                        | `default`                 |
+| `persistence.accessMode`                  | Access mode of the persistence volume                               | `ReadWriteOnce`           |
+| `persistence.size`                        | Internal port of the k8s service                                    | `3306`                    |
+| `template.labels`                         | Labels to be added to the elasticsearch pod                         | `{}`                      |
+| `resources`                               | Resources limits and requests for elasticsearch                     | `{}`                      |
+| `networkPolicy.enabled`                   | Use network policy to filter ingress connections to elasticsearch   | `false`                   |
+| `networkPolicy.allowExternal`             | Allow all ingress connections to elasticsearch                      | `nil`                     |

--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -25,13 +25,6 @@ Initialize data into the elasticsearch indices if it is not present.
   set -ex
   # Exit if data is already persisted
   [[ -d /data/elasticsearch ]] && exit 0
-  # Download datafile from the object storage provider
-  set +ex # Remove logging to avoid credentials leaking
-  mc config host add $OS_PROVIDER $OS_HOST $OS_ACCESS_KEY_ID $OS_SECRET_ACCESS_KEY --api S3v4
-  set -ex
-  mc cp $OS_PROVIDER/$OS_BUCKET/{{ .Values.initData.datafile }} .
-  # Untar elasticsearch data into data persistence volume
-  tar -C /data --strip-components=1 -xvf {{ .Values.initData.datafile }} {{ .Values.initData.sourceDirectory }}
-  # Remove useless archive
-  rm {{ .Values.initData.datafile }}
+  # Download datafile from the object storage provider and untar elasticsearch data from it into data persistence volume
+  aws s3 cp s3://$OS_BUCKET/{{ .Values.initData.datafile }} - | tar -C /data --strip-components=1 -xzvf - {{ .Values.initData.sourceDirectory }}
 {{- end }}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -39,22 +39,18 @@ spec:
       - name: init-data
         image: {{ .Values.initData.image }}
         env:
-        - name: OS_PROVIDER
-          value: {{ .Values.initData.objectStorage.provider | quote }}
         - name: OS_BUCKET
           value: {{ .Values.initData.objectStorage.bucket | quote }}
-        - name: OS_ACCESS_KEY_ID
+        - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
               name: {{ .Values.initData.objectStorage.secretKeyRefName }}
               key: access-key-id
-        - name: OS_SECRET_ACCESS_KEY
+        - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
               name: {{ .Values.initData.objectStorage.secretKeyRefName }}
               key: secret-access-key
-        - name: OS_HOST
-          value: {{ .Values.initData.objectStorage.host | quote }}
         command:
         {{- include "elasticsearch.initData" . | indent 10 }}
         volumeMounts:

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -7,15 +7,13 @@ image: elasticsearch:2.3
 
 initData:
   enabled: false
-  image: minio/mc:latest
+  image: jobteaser/awscli:latest
   # datafile: my.data.file.path
   # sourceDirectory: mydirectory
   objectStorage: {}
     # To define object storage values, uncomment the following lines, adjust them as
     # necessary, and remove the curly braces after 'objectStorage:'.
-    # provider: s3
     # bucket: mybucket
-    # host: https://<objectStorage-host>:9000
     # We are looking for access-key-id and secret-access-key in this secret.
     # secretKeyRefName: object-storage
 


### PR DESCRIPTION
minio mc command often has incompatibilities with AWS S3:
- switching to awscli
- piping output to tar to avoid too much disk IO