### PR TITLE
[IN-790]Implement ES snapshot restore

### DIFF
--- a/elasticsearch/Chart.yaml
+++ b/elasticsearch/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Elasticsearch
 name: elasticsearch
-version: 2.0.3
+version: 2.1.0

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -25,21 +25,26 @@ The following tables lists the configurable parameters of the elasticsearch char
 | `image`   | `elasticsearch` image repository and tag | `elasticsearch:2.3` |
 
 ### Expert
-| Parameter                                 | Description                                                         | Default                   |
-| ---                                       | ---                                                                 | ---                       |
-| `initData.enabled`                        | Use init container to inject data into elasticsearch                | `false`                   |
-| `initData.image`                          | Image and tag used by the init container of data initialization     | `jobteaser/awscli:latest` |
-| `initData.datafile`                       | Name of the file to download                                        | `nil`                     |
-| `initData.objectStorage.bucket`           | Name of the bucket to download the datafile from                    | `nil`                     |
-| `initData.objectStorage.secretKeyRefName` | Name of the k8s secret with `access_key_id` and `secret_access_key` | `nil`                     |
-| `service.name`                            | Name of the k8s service                                             | `es`                      |
-| `service.type`                            | Type of the k8s service                                             | `ClusterIP`               |
-| `service.externalPort`                    | External port exposed by the k8s service                            | `3306`                    |
-| `service.internalPort`                    | Internal port of the k8s service                                    | `3306`                    |
-| `persistence.storageClassName`            | Storage class name of the persistence volume                        | `default`                 |
-| `persistence.accessMode`                  | Access mode of the persistence volume                               | `ReadWriteOnce`           |
-| `persistence.size`                        | Internal port of the k8s service                                    | `3306`                    |
-| `template.labels`                         | Labels to be added to the elasticsearch pod                         | `{}`                      |
-| `resources`                               | Resources limits and requests for elasticsearch                     | `{}`                      |
-| `networkPolicy.enabled`                   | Use network policy to filter ingress connections to elasticsearch   | `false`                   |
-| `networkPolicy.allowExternal`             | Allow all ingress connections to elasticsearch                      | `nil`                     |
+| Parameter                                  | Description                                                         | Default                   |
+| ---                                        | ---                                                                 | ---                       |
+| `initData.enabled`                         | Use init container to inject data into elasticsearch                | `false`                   |
+| `initData.image`                           | Image and tag used by the init container of data initialization     | `jobteaser/awscli:latest` |
+| `initData.datafile`                        | Name of the file to download                                        | `nil`                     |
+| `initData.sourceDirectory`                 | elasticsearch data source directory in the datafile                 | `nil`                     |
+| `initData.objectStorage.bucket`            | Name of the bucket to download the datafile from                    | `nil`                     |
+| `initData.objectStorage.secretKeyRefName`  | Name of the k8s secret with `access_key_id` and `secret_access_key` | `nil`                     |
+| `initData.restoreSnapshot.enabled`         | Restore a snapshot from initData source                             | `false`                   |
+| `initData.restoreSnapshot.sourceDirectory` | Snapshot source directory in the datafile                           | `snapshots`               |
+| `initData.restoreSnapshot.repository`      | Snapshot respository name                                           | `backup`                  |
+| `initData.restoreSnapshot.name`            | Snapshot name                                                       | `snapshot_1`              |
+| `service.name`                             | Name of the k8s service                                             | `es`                      |
+| `service.type`                             | Type of the k8s service                                             | `ClusterIP`               |
+| `service.externalPort`                     | External port exposed by the k8s service                            | `3306`                    |
+| `service.internalPort`                     | Internal port of the k8s service                                    | `3306`                    |
+| `persistence.storageClassName`             | Storage class name of the persistence volume                        | `default`                 |
+| `persistence.accessMode`                   | Access mode of the persistence volume                               | `ReadWriteOnce`           |
+| `persistence.size`                         | Internal port of the k8s service                                    | `3306`                    |
+| `template.labels`                          | Labels to be added to the elasticsearch pod                         | `{}`                      |
+| `resources`                                | Resources limits and requests for elasticsearch                     | `{}`                      |
+| `networkPolicy.enabled`                    | Use network policy to filter ingress connections to elasticsearch   | `false`                   |
+| `networkPolicy.allowExternal`              | Allow all ingress connections to elasticsearch                      | `nil`                     |

--- a/elasticsearch/templates/_helpers.tpl
+++ b/elasticsearch/templates/_helpers.tpl
@@ -26,5 +26,42 @@ Initialize data into the elasticsearch indices if it is not present.
   # Exit if data is already persisted
   [[ -d /data/elasticsearch ]] && exit 0
   # Download datafile from the object storage provider and untar elasticsearch data from it into data persistence volume
+{{- if .Values.initData.restoreSnapshot.enabled }}
+  aws s3 cp s3://$OS_BUCKET/{{ .Values.initData.datafile }} - | tar -C /snapshots --strip-components=1 -xzvf - {{ .Values.initData.restoreSnapshot.sourceDirectory }}
+{{- else }}
   aws s3 cp s3://$OS_BUCKET/{{ .Values.initData.datafile }} - | tar -C /data --strip-components=1 -xzvf - {{ .Values.initData.sourceDirectory }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Initialize data into the elasticsearch indices if it is not present.
+*/}}
+{{ define "elasticsearch.restoreSnapshot" }}
+- sh
+- "-c"
+- |
+  set -ex
+  # Exit if no snapshot is present
+  [ -d /usr/share/elasticsearch/data/snapshots ] || exit 0
+  # Download datafile from the object storage provider and untar elasticsearch data from it into data persistence volume
+  /docker-entrypoint.sh elasticsearch -p /run/elasticsearch/es.pid -d --path.repo=/usr/share/elasticsearch/data/snapshots
+  echo Waiting for ES to be up...
+  while ! curl >/dev/null 2>&1 localhost:9200; do
+    sleep 2
+  done
+
+  echo ES is up.
+  sleep 2
+
+  echo Restoring snasphot...
+  curl -XPOST "localhost:9200/_all/_close?allow_no_indices=true&expand_wildcards=all&wait_for_completion=true"
+  curl -XPUT "localhost:9200/_snapshot/{{ .Values.initData.restoreSnapshot.repository }}" -d '{"type": "fs", "settings": {"compress": "true", "location": "/usr/share/elasticsearch/data/snapshots"}}}'
+  curl -XPOST "localhost:9200/_snapshot/{{ .Values.initData.restoreSnapshot.repository }}/{{ .Values.initData.restoreSnapshot.name }}/_restore?wait_for_completion=true"
+  curl -XPOST "localhost:9200/_all/_open?allow_no_indices=true&expand_wildcards=all&wait_for_completion=true"
+  curl -XDELETE localhost:9200/_snapshot/{{ .Values.initData.restoreSnapshot.repository }}/{{ .Values.initData.restoreSnapshot.name }}
+  kill -15 $(cat /run/elasticsearch/es.pid)
+
+  echo Restore successful, removing snapshot.
+  rm -rf /usr/share/elasticsearch/data/snapshots/*
 {{- end }}

--- a/elasticsearch/templates/statefulset.yaml
+++ b/elasticsearch/templates/statefulset.yaml
@@ -57,6 +57,24 @@ spec:
         - name: data
           mountPath: /data
           subPath: elasticsearch
+        {{- if .Values.initData.restoreSnapshot.enabled }}
+        - name: data
+          mountPath: /snapshots
+          subPath: snapshots
+        {{- end }}
+      {{- if .Values.initData.restoreSnapshot.enabled }}
+      - name: restore-snapshot
+        image: {{ .Values.image }}
+        command:
+        {{- include "elasticsearch.restoreSnapshot" . | indent 10 }}
+        volumeMounts:
+        - name: data
+          mountPath: /usr/share/elasticsearch/data/elasticsearch
+          subPath: elasticsearch
+        - name: data
+          mountPath: /usr/share/elasticsearch/data/snapshots
+          subPath: snapshots
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ template "elasticsearch.name" . }}

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -16,6 +16,11 @@ initData:
     # bucket: mybucket
     # We are looking for access-key-id and secret-access-key in this secret.
     # secretKeyRefName: object-storage
+  restoreSnapshot:
+    enabled: false
+    sourceDirectory: snapshots
+    repository: backup
+    name: snapshot_1
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Add snapshot restore to elasticsearch chart:
- use the same archive file to provide snapshot content
- dedicated initContainer to restore it
- backward compatible with current implementation

See README for usage.
See benchmark in https://jobteaser.atlassian.net/browse/IN-790