### PR TITLE
Implement SQL dump restore

### DIFF
--- a/mysql/Chart.yaml
+++ b/mysql/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for MySQL
 name: mysql
-version: 1.0.3
+version: 1.1.0

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -34,6 +34,9 @@ The following tables lists the configurable parameters of the MySQL chart and th
 | `initData.datafile`                       | Name of the file to download                                        | `nil`                     |
 | `initData.objectStorage.bucket`           | Name of the bucket to download the datafile from                    | `nil`                     |
 | `initData.objectStorage.secretKeyRefName` | Name of the k8s secret with `access_key_id` and `secret_access_key` | `nil`                     |
+| `initData.sqlRestore.enbled`              | Use init container to restore dump into MySQL                       | `false`                   |
+| `initData.sqlRestore.datafile`            | Name of the SQL dump file to download                               | `nil`                     |
+| `initData.sqlRestore.tableName`           | Name of the target table for SQL dump restore                       | `nil`                     |
 | `service.name`                            | Name of the k8s service                                             | `mysql`                   |
 | `service.type`                            | Type of the k8s service                                             | `ClusterIP`               |
 | `service.externalPort`                    | External port exposed by the k8s service                            | `3306`                    |

--- a/mysql/templates/_helpers.tpl
+++ b/mysql/templates/_helpers.tpl
@@ -26,5 +26,38 @@ Initialize data into the MySQL database if it is not present.
   # Exit if data is already persisted
   [[ -d /data/mysql ]] && exit 0
   # Download datafile from the object storage provider and extract it
+{{- if .Values.initData.restoreSql.enabled }}
+  aws s3 cp s3://$OS_BUCKET/{{ .Values.initData.restoreSql.sqlfile }} - | gunzip > /initdb/{{ .Values.initData.restoreSql.tableName }}.sql.gz
+{{- else }}
   aws s3 cp s3://$OS_BUCKET/{{ .Values.initData.datafile }} - | tar -C /data --strip-components=1 -xzvf - mysql
+{{- end }}
+{{- end }}
+
+{{/*
+Initialize data into the elasticsearch indices if it is not present.
+*/}}
+{{ define "mysql.restoreSql" }}
+- sh
+- "-c"
+- |
+  set -e
+  # Exit if no mysql dump is present
+  [ -f /initdb/{{ .Values.initData.restoreSql.tableName }}.sql.gz ] || exit 0
+  # Apply mysql dump
+  docker-entrypoint.sh mysqld --wait_timeout=28800 --innodb_log_file_size=128M --max_allowed_packet=128M &
+  pid="$!"
+  echo Waiting for MySQL to be up...
+  while ! mysql > /dev/null -uroot -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1' >/dev/null; do
+    sleep 2
+  done
+
+  echo MySQL is up.
+  sleep 2
+
+  echo Restoring SQL dump...
+  mysql -u root -p${MYSQL_ROOT_PASSWORD} {{ .Values.initData.restoreSql.tableName }} < /initdb/{{ .Values.initData.restoreSql.tableName }}.sql.gz
+  kill -15 $pid
+
+  echo Restore successful, removing SQL dump
+  rm -rf /initdb/*
 {{- end }}

--- a/mysql/templates/statefulset.yaml
+++ b/mysql/templates/statefulset.yaml
@@ -44,6 +44,42 @@ spec:
         - name: data
           mountPath: /data
           subPath: mysql
+        {{- if .Values.initData.restoreSql.enabled }}
+        - name: data
+          mountPath: /initdb
+          subPath: initdb
+        {{- end }}
+      {{- if .Values.initData.restoreSql.enabled }}
+      - name: restore-sql
+        image: {{ .Values.image }}
+        command:
+        {{- include "mysql.restoreSql" . | indent 10 }}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+          subPath: mysql
+        - name: data
+          mountPath: /initdb
+          subPath: initdb
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secretKeyRefName }}
+              key: root_password
+        - name: MYSQL_DATABASE
+          value: {{ .Values.database }}
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secretKeyRefName }}
+              key: username
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secretKeyRefName }}
+              key: password
+      {{- end }}
       {{- end }}
       containers:
       - name: mysql

--- a/mysql/values.yaml
+++ b/mysql/values.yaml
@@ -19,6 +19,10 @@ initData:
     # bucket:
     # We are looking for access-key-id and secret-access-key in this secret.
     # secretKeyRefName:
+  restoreSql:
+    enabled: false
+    # tableName:
+    # sqlfile:
 
 service:
   name: mysql


### PR DESCRIPTION
Add SQL dump restore to mysql chart:
- use a dedicated SQL dump file in the same S3 bucket than the datafile
- dedicated initContainer to restore the dump (and the datafile extraction will not be done if SQL dump restore is enabled)
- backward compatible with current implementation
See README for usage.
See benchmark in https://jobteaser.atlassian.net/browse/IN-789