### PR TITLE
[IN-634] Reverts filebeat chart and bump version

### DIFF
--- a/kubernetes-filebeat/Chart.yaml
+++ b/kubernetes-filebeat/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "6.7.1"
+appVersion: "6.2.1"
 description: Filebeat log collector
 name: kubernetes-filebeat
-version: 0.3.1
+version: 0.4.0

--- a/kubernetes-filebeat/templates/configuration/_filebeat-node.yml.tpl
+++ b/kubernetes-filebeat/templates/configuration/_filebeat-node.yml.tpl
@@ -17,9 +17,6 @@ filebeat.autodiscover:
   providers:
 
   - type: kubernetes
-    labels.dedot: true
-    annotations.dedot: true
-
     include_annotations:
     - log/format
     - log/multiline-pattern

--- a/kubernetes-filebeat/templates/daemonset-master.yaml
+++ b/kubernetes-filebeat/templates/daemonset-master.yaml
@@ -37,10 +37,11 @@ spec:
           runAsUser: 0
         resources:
           limits:
-            memory: 200Mi
+            cpu: 500m
+            memory: 500Mi
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 500m
+            memory: 500Mi
         volumeMounts:
         - name: config
           mountPath: /etc/filebeat.yml

--- a/kubernetes-filebeat/templates/daemonset-nodes.yaml
+++ b/kubernetes-filebeat/templates/daemonset-nodes.yaml
@@ -35,10 +35,11 @@ spec:
           runAsUser: 0
         resources:
           limits:
-            memory: 200Mi
+            cpu: 500m
+            memory: 500Mi
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 500m
+            memory: 500Mi
         volumeMounts:
         - name: config
           mountPath: /etc/filebeat.yml

--- a/kubernetes-filebeat/values.yaml
+++ b/kubernetes-filebeat/values.yaml
@@ -1,8 +1,8 @@
 
 app:
   cluster_service: true
-  master_image:  docker.elastic.co/beats/filebeat:6.7.1
-  node_image: docker.elastic.co/beats/filebeat:6.7.1
+  master_image:  docker.elastic.co/beats/filebeat:6.2.1
+  node_image: docker.elastic.co/beats/filebeat:6.2.1
 
 loglevel: info
 


### PR DESCRIPTION
This reverts commit 4f912f3aa68b516b590b3978602a3abd7ab64457.

Revert "[IN-634] Update filebeat (#73)"

This reverts commit 8135c6a650626d3ce085a910285721d789b58fb2.

Reverts filebeat chart and bump version

[IN-634]: https://jobteaser.atlassian.net/browse/IN-634